### PR TITLE
Change Confirmations from 0 to 2, possibly reduce re-orgs?

### DIFF
--- a/bin/build-compose.sh
+++ b/bin/build-compose.sh
@@ -45,7 +45,7 @@ EOF
       '--peer=0247e289aa332260b99dfd50e578f779df9e6702d67e50848bb68f3e0737d9b9a5,9c-main-seed-3.planetarium.dev,31234',
       '--trusted-app-protocol-version-signer=03eeedcd574708681afb3f02fb2aef7c643583089267d17af35e978ecaf2a1184e',
       '--workers=500',
-      '--confirmations=0',
+      '--confirmations=2',
       '--libplanet-node',
       '--ice-server=turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478',
       '--ice-server=turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478',


### PR DESCRIPTION
0 may have been an original setting from early headless settings. Current game launcher uses 2.